### PR TITLE
本リリースまでコストを抑えるためにECSをpublicに移し替えてNATを削除した

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -19,7 +19,7 @@ resource "aws_lb_listener" "https" {
   certificate_arn   = aws_acm_certificate.tokyo.arn
   default_action {
     type             = "forward"
-    target_group_arn = aws_alb_target_group.ecs_target_group.arn
+    target_group_arn = aws_alb_target_group.ecs_target_group_v2.arn
   }
 }
 
@@ -40,10 +40,10 @@ resource "aws_lb_listener" "http_to_https" {
 }
 
 # --------------------------
-# Target Group
+# Target Group v2
 # --------------------------
-resource "aws_alb_target_group" "ecs_target_group" {
-  name        = "${var.project}-ecs-tg"
+resource "aws_alb_target_group" "ecs_target_group_v2" {
+  name        = "${var.project}-ecs-tg-v2"
   port        = 3000
   protocol    = "HTTP"
   vpc_id      = aws_vpc.vpc.id
@@ -57,6 +57,6 @@ resource "aws_alb_target_group" "ecs_target_group" {
   }
 
   tags = {
-    Name = "${var.project}-ecs-tg"
+    Name = "${var.project}-ecs-tg-v2"
   }
 }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -25,10 +25,10 @@ resource "aws_ecs_task_definition" "rails_task" {
 }
 
 # --------------------------
-# service
+# service v2
 # --------------------------
-resource "aws_ecs_service" "tasting-note" {
-  name                              = "${var.project}-service"
+resource "aws_ecs_service" "tasting_note_v2" {
+  name                              = "${var.project}-service-v2"
   cluster                           = aws_ecs_cluster.tasting_note.arn
   task_definition                   = aws_ecs_task_definition.rails_task.arn
   desired_count                     = 2
@@ -37,13 +37,13 @@ resource "aws_ecs_service" "tasting-note" {
   health_check_grace_period_seconds = 60
 
   network_configuration {
-    assign_public_ip = false
+    assign_public_ip = true
     security_groups  = [aws_security_group.ecs_sg.id]
-    subnets          = [for subnet in aws_subnet.ecs_private : subnet.id]
+    subnets          = [for subnet in aws_subnet.public : subnet.id]
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.ecs_target_group.arn
+    target_group_arn = aws_alb_target_group.ecs_target_group_v2.arn
     container_name   = "${var.project}-container"
     container_port   = 3000
   }

--- a/terraform/eip.tf
+++ b/terraform/eip.tf
@@ -1,8 +1,8 @@
-resource "aws_eip" "nat_gateway" {
-  for_each = toset(var.availability_zone)
-  vpc      = true
+# resource "aws_eip" "nat_gateway" {
+#   for_each = toset(var.availability_zone)
+#   vpc      = true
 
-  tags = {
-    Name = "${var.project}-eip-${each.key}"
-  }
-}
+#   tags = {
+#     Name = "${var.project}-eip-${each.key}"
+#   }
+# }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -129,24 +129,24 @@ resource "aws_route" "public_rt_igw_route" {
 # --------------------------
 # NAT Gateway
 # --------------------------
-resource "aws_nat_gateway" "for_ecs" {
-  for_each = toset(var.availability_zone)
+# resource "aws_nat_gateway" "for_ecs" {
+#   for_each = toset(var.availability_zone)
 
-  allocation_id = aws_eip.nat_gateway[each.key].id
-  subnet_id     = aws_subnet.public[each.key].id
+#   allocation_id = aws_eip.nat_gateway[each.key].id
+#   subnet_id     = aws_subnet.public[each.key].id
 
-  tags = {
-    Name = "${var.project}-nat-gateway-${each.key}"
-  }
+#   tags = {
+#     Name = "${var.project}-nat-gateway-${each.key}"
+#   }
 
-  depends_on = [
-    aws_internet_gateway.igw
-  ]
-}
+#   depends_on = [
+#     aws_internet_gateway.igw
+#   ]
+# }
 
-resource "aws_route" "private_rt_nat_gateway_route" {
-  for_each               = toset(var.availability_zone)
-  route_table_id         = aws_route_table.private_ecs_rt[each.key].id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.for_ecs[each.key].id
-}
+# resource "aws_route" "private_rt_nat_gateway_route" {
+#   for_each               = toset(var.availability_zone)
+#   route_table_id         = aws_route_table.private_ecs_rt[each.key].id
+#   destination_cidr_block = "0.0.0.0/0"
+#   nat_gateway_id         = aws_nat_gateway.for_ecs[each.key].id
+# }


### PR DESCRIPTION
## What
- NATの削除
- ECS V2の作成
- TargetGroup V2の作成
- ElasticIPの削除
- サービスが止まらないように無停止で切り替え

## Why
- 本リリースまでコストを抑えるため