### PR TITLE
画像をアップロードするためのS3バケットを用意した

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -43,8 +43,9 @@ resource "aws_acm_certificate_validation" "tokyo_cert_valid" {
 resource "aws_acm_certificate" "virginia" {
   provider = aws.virginia
 
-  domain_name       = "${var.project}.com"
-  validation_method = "DNS"
+  domain_name               = "${var.project}.com"
+  subject_alternative_names = ["images.${var.project}.com"]
+  validation_method         = "DNS"
 
   tags = {
     Name = "${var.project}-sslcert-virginia"

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,3 +1,6 @@
+# --------------------------
+# Cloudfront for S3 Web Hosting
+# --------------------------
 resource "aws_cloudfront_distribution" "cf" {
   enabled             = true
   is_ipv6_enabled     = true
@@ -56,4 +59,59 @@ resource "aws_cloudfront_distribution" "cf" {
 
 resource "aws_cloudfront_origin_access_identity" "cf_s3_origin_access_identity" {
   comment = "s3 web hosting bucket access identity"
+}
+
+# --------------------------
+# Cloudfront for S3 images
+# --------------------------
+resource "aws_cloudfront_distribution" "cf_images" {
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_All"
+
+  origin {
+    domain_name = aws_s3_bucket.images.bucket_regional_domain_name
+    origin_id   = aws_s3_bucket.images.id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.cf_s3_images_origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_s3_bucket.images.id
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  aliases = ["images.${var.project}.com"]
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.virginia.arn
+    minimum_protocol_version = "TLSv1.2_2019"
+    ssl_support_method       = "sni-only"
+  }
+}
+
+resource "aws_cloudfront_origin_access_identity" "cf_s3_images_origin_access_identity" {
+  comment = "s3 images bucket access identity"
 }

--- a/terraform/iam_policy.tf
+++ b/terraform/iam_policy.tf
@@ -44,3 +44,10 @@ data "aws_iam_policy" "ecs_full_access" {
 data "aws_iam_policy" "cf_full_access" {
   arn = "arn:aws:iam::aws:policy/CloudFrontFullAccess"
 }
+
+# -----------------------
+# S3 full access
+# -----------------------
+data "aws_iam_policy" "s3_full_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}

--- a/terraform/iam_role.tf
+++ b/terraform/iam_role.tf
@@ -21,3 +21,16 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   role       = aws_iam_role.ecs_task_execution.name
   policy_arn = aws_iam_policy.ecs_task_execution.arn
 }
+
+# -------------------------------
+# IAM Role for ecs task role
+# -------------------------------
+resource "aws_iam_role" "ecs_task" {
+  name               = "TastingNoteEcsTaskRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task" {
+  role       = aws_iam_role.ecs_task.name
+  policy_arn = data.aws_iam_policy.s3_full_access.arn
+}

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -7,7 +7,7 @@ data "aws_route53_zone" "tasting_note" {
 }
 
 # --------------------------
-# A record for Cloud Front
+# A record for Cloudfront Web Hosting
 # --------------------------
 resource "aws_route53_record" "cloudfront" {
   zone_id = data.aws_route53_zone.tasting_note.zone_id
@@ -32,6 +32,21 @@ resource "aws_route53_record" "alb" {
   alias {
     name                   = aws_lb.alb.dns_name
     zone_id                = aws_lb.alb.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# --------------------------
+# A record for Cloudfront Images
+# --------------------------
+resource "aws_route53_record" "cf_images" {
+  zone_id = data.aws_route53_zone.tasting_note.zone_id
+  name    = "images.${var.project}.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cf_images.domain_name
+    zone_id                = aws_cloudfront_distribution.cf_images.hosted_zone_id
     evaluate_target_health = true
   }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -57,3 +57,39 @@ data "aws_iam_policy_document" "s3_web_hosting" {
     }
   }
 }
+
+# --------------------------
+# S3 for Images
+# --------------------------
+resource "aws_s3_bucket" "images" {
+  bucket = "${var.project}-images"
+}
+
+resource "aws_s3_bucket_public_access_block" "images" {
+  bucket                  = aws_s3_bucket.images.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+  depends_on = [
+    aws_s3_bucket_policy.images
+  ]
+}
+
+resource "aws_s3_bucket_policy" "images" {
+  bucket = aws_s3_bucket.images.id
+  policy = data.aws_iam_policy_document.s3_images.json
+}
+
+data "aws_iam_policy_document" "s3_images" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipal"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.images.arn}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.cf_s3_images_origin_access_identity.iam_arn]
+    }
+  }
+}


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note/issues/69

## What
- 画像アップロード用にS3バケットを追加
- ECSからS3へアクセスするためのTaskロール用IAMロールの追加
- フロントエンドから画像を取得するためのCloudfrontを追加
- 画像取得用Cloudfrontに使用するドメインのエイリアスを追加
- 画像取得用CloudfrontにAレコードの追加

## Why
- 画像アップロード機能を追加するため