### PR TITLE
ECSのTask roleを指定してRailsからS3にアクセスできるようにした

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -16,6 +16,7 @@ resource "aws_ecs_task_definition" "rails_task" {
   requires_compatibilities = ["FARGATE"]
 
   execution_role_arn = aws_iam_role.ecs_task_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task.arn
 
   container_definitions = templatefile("./task_definitions/rails_container_definitions.json", {
     project               = var.project


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note/issues/69

## What
- ECSで指定するTask definitionにS3へアクセスするためのTask roleを追加した

## Why
- 本番環境でRailsからS3へアクセスするため