### PR TITLE
Rails用のコンテナの数を1つに変更した

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_service" "tasting_note_v2" {
   name                              = "${var.project}-service-v2"
   cluster                           = aws_ecs_cluster.tasting_note.arn
   task_definition                   = aws_ecs_task_definition.rails_task.arn
-  desired_count                     = 2
+  desired_count                     = 1
   launch_type                       = "FARGATE"
   platform_version                  = "1.4.0"
   health_check_grace_period_seconds = 60


### PR DESCRIPTION
## What
- Rails用のECSの数を2つから1つに変更した

## Why
- 料金を抑えるため